### PR TITLE
Issue 18: Fixed - properly locating the socket under /run with appropriate 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ make
 
 There is a service file for systemd in radeon-profile-daemon/extra. If installed manually, copy service file to `/etc/systemd/system/`. After that, execute `systemctl enable radeon-profile-daemon.service` and `systemctl start radeon-profile-daemon.service` to make the daemon running.
 
+# tmpfiles
+
+There is a tmpfiles file that can be used by opentmpfiles or systemd-tmpfiles in radeon-profile-daemon/extra. If installed, it will make sure the /run/radeon-profile-daemon directory is created with the correct ownership and permissions.
+
 # Links
 
 * AUR package: https://aur.archlinux.org/packages/radeon-profile-daemon-git

--- a/radeon-profile-daemon/extra/radeon-profile-daemon.tmpfiles
+++ b/radeon-profile-daemon/extra/radeon-profile-daemon.tmpfiles
@@ -1,0 +1,1 @@
+d /run/radeon-profile-daemon 0750 root video -

--- a/radeon-profile-daemon/rpdthread.cpp
+++ b/radeon-profile-daemon/rpdthread.cpp
@@ -47,7 +47,7 @@ void rpdThread::createServer()
 
     QLocalServer::removeServer(serverSocketPath);
     daemonServer.listen(serverSocketPath);
-    QFile::setPermissions(serverSocketPath, QFile(serverSocketPath).permissions() | QFile::WriteOther | QFile::ReadOther);
+    QFile::setPermissions(serverSocketPath, QFile(serverSocketPath).permissions() | QFile::WriteGroup);
 }
 
 void rpdThread::closeConnection()

--- a/radeon-profile-daemon/rpdthread.h
+++ b/radeon-profile-daemon/rpdthread.h
@@ -31,7 +31,7 @@
 #define SIGNAL_ALIVE '7'
 
 const QString appVersion = "20190603";
-const QString serverSocketPath = "/run/radeon-profile-daemon-server";
+const QString serverSocketPath = "/run/radeon-profile-daemon/radeon-profile-daemon-server";
 
 class rpdThread : public QThread
 {


### PR DESCRIPTION
Fixes https://github.com/marazmista/radeon-profile-daemon/issues/18

Move socket under /run
Set appropriate rights
Add a .tmpfiles so the path for the socket is created if/when needed